### PR TITLE
Allow users to customize supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ echo "a: "a
 echom "a: ".type(a)
 ```
 
-## Customerization
+## Customization
 
 To change a map, add a `let` statement in your `vimrc`. Example: 
 
@@ -68,6 +68,43 @@ Default set:
 >   let g:easy_log_type_upper_map_key='<leader>tL'
 
 You Could remap it to your favourite key.
+
+### Adding languages
+
+If you would like to support more languages, you can use the
+`g:easy_log_log_map` and `g:easy_log_type_map` variables. For example, to add Ruby:
+
+```viml
+let g:easy_log_log_map={
+      \'ruby':['puts "', ': " + ', ''],
+      \}
+
+let g:easy_log_type_map={
+      \'ruby':['puts "', '.class: " + ', '.class.to_s'],
+      \}
+```
+
+The variables should each be assigned a dictionary. The dictionary keys are the
+languages (filetypes), and the assigned values are arrays.
+
+Each array can have any number of elements. These elements are `join`ed with the variable name.
+If we take the Ruby example, and the variable name is `first_name`, the output looks like this:
+
+```
+first_name = "Alice"
+puts "first_name: " + first_name
+```
+
+and if you use the type logger instead, it looks like:
+
+```
+first_name = "Alice"
+puts "first_name.class: " + first_name.class.to_s
+```
+
+#### Bonus: Overriding the supported languages
+
+You can also override the output for each of the supported languages that ship with the plugin by adding the same languages to your own configuration. See [the implementation](plugin/easylog.vim) for a starting point. 
 
 ## Bugs
 

--- a/plugin/easylog.vim
+++ b/plugin/easylog.vim
@@ -7,9 +7,16 @@ if exists("g:loaded_easylog") || v:version < 700
 endif
 let g:loaded_easylog = 1
 
+if !exists("g:easy_log_log_map")
+  let g:easy_log_log_map = {}
+endif
+
+if !exists("g:easy_log_type_map")
+  let g:easy_log_type_map = {}
+endif
 
 " map {{{
-let s:log_map={
+let s:default_log_map={
       \'javascript':['console.log("', '", ', ')'],
       \'typescript':['console.log("', '", ', ')'],
       \'go':['fmt.Println("', '", ', ')'],
@@ -17,13 +24,16 @@ let s:log_map={
       \'vim':['echo "', ': "',''],
       \}
 
-let s:type_map={
+let s:default_type_map={
       \'javascript':['console.log("', ': ", Object.prototype.toString.call(', '))'],
       \'typescript':['console.log("', ': ", Object.prototype.toString.call(', '))'],
       \'go':['fmt.Printf("', ': %T\n", ', ')'],
       \'python':['print("', ': ", type(', '))'],
       \'vim':['echom "', ': ".type(',')'],
       \}
+
+let s:log_map = extend(s:default_log_map, g:easy_log_log_map)
+let s:type_map = extend(s:default_type_map, g:easy_log_type_map)
 " }}}
 
 " tools {{{


### PR DESCRIPTION
Thanks again for this awesome plugin. I took a shot at implementing the ability for users to add languages that they would like to support. For example, here is my configuration which adds Ruby and Lua support:

```viml
let g:easy_log_log_map={
      \'ruby':['puts "', ': " + ', ''],
      \'lua':['print("', ':", ', ')'],
      \}

let g:easy_log_type_map={
      \'ruby':['puts "', '.class: " + ', '.class.to_s'],
      \'lua':['print("type(', '):", type(', '))'],
      \}
```
---

I look forward to receiving your feedback, and I hope you like my idea and implementation! I do not know the other language the readme is written in, so I would appreciate it if you could translate my addition to the English readme into the other one.